### PR TITLE
rule should not barf on a CallExpression result being called again

### DIFF
--- a/lib/rules/method.js
+++ b/lib/rules/method.js
@@ -71,10 +71,12 @@ module.exports = {
                     break;
                 case "Super":
                     break;
+                case "CallExpression":
+                    break;
 
                 // If we don't cater for this expression throw an error
                 default:
-                    context.reportUnsupported(node, "Unexpected Callee", "Unsupported Callee for CallExpression");
+                    ruleHelper.reportUnsupported(node, "Unexpected Callee", "Unsupported Callee for CallExpression");
                 }
             }
         };

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -96,6 +96,11 @@ eslintTester.run("method", rule, {
                 }
             ]
         },
+
+        // rule should not barf on a CallExpression result being called again
+        {
+            code: "  _tests.shift()();",
+        }
     ],
 
     // Examples of code that should trigger the rule


### PR DESCRIPTION
>            code: "  _tests.shift()();", 
makes the rule throw an exception.
This pull request fixes it and adds a test.

Also, error reporting was broken for those cases, so I fixed that while I was at it