### PR TITLE
Fix unexpected callee newexpression (fix #73)

### DIFF
--- a/lib/rules/method.js
+++ b/lib/rules/method.js
@@ -64,6 +64,7 @@ function checkCallExpression(ruleHelper, callExpr, node) {
     case "Super":
     case "CallExpression":
     case "ThisExpression":
+    case "NewExpression":
         break;
 
     // If we don't cater for this expression throw an error

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -115,6 +115,11 @@ eslintTester.run("method", rule, {
         // issue 71 https://github.com/mozilla/eslint-plugin-no-unsanitized/issues/71
         {
             code: "function foo() { return this().bar(); };",
+        },
+
+        // issue 73 https://github.com/mozilla/eslint-plugin-no-unsanitized/issues/73
+        {
+            code: "new Function()();",
         }
     ],
 


### PR DESCRIPTION
The return value of a NewExpression can't be scanned so easily with a linter, so I'm allowing all NewExpressions.

Can you take a brief look @jonathanKingston?