### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/lib/rules/method.js
+++ b/lib/rules/method.js
@@ -76,7 +76,8 @@ module.exports = {
     meta: {
         docs: {
             description: "ESLint rule to disallow unsanitized method calls",
-            category: "possible-errors"
+            category: "possible-errors",
+            url: "https://github.com/mozilla/eslint-plugin-no-unsanitized/tree/master/docs/rules/method.md"
         },
         /* schema statement TBD until we have options
         schema: [

--- a/lib/rules/property.js
+++ b/lib/rules/property.js
@@ -28,7 +28,8 @@ module.exports = {
     meta: {
         docs: {
             description: "ESLint rule to disallow unsanitized property assignment",
-            category: "possible-errors"
+            category: "possible-errors",
+            url: "https://github.com/mozilla/eslint-plugin-no-unsanitized/tree/master/docs/rules/property.md"
         },
         /* schema statement TBD until we have options
         schema: [


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.