### PR TITLE
Update eslint to version 4.16.0 

### DIFF
--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -201,9 +201,9 @@ RuleHelper.prototype = {
         Object.keys(childRuleChecks).forEach((ruleCheckKey) => {
             // However if they have missing keys merge with default
             const ruleCheck = Object.assign({},
-                                            defaultRuleChecks[ruleCheckKey],
-                                            parentRuleChecks,
-                                            childRuleChecks[ruleCheckKey]);
+                defaultRuleChecks[ruleCheckKey],
+                parentRuleChecks,
+                childRuleChecks[ruleCheckKey]);
             ruleCheckOutput[ruleCheckKey] = ruleCheck;
         });
         return ruleCheckOutput;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "mocha": "^3.2.0"
     },
     "dependencies": {
-        "eslint": "^3.19.0"
+        "eslint": "^4.16.0"
     },
     "homepage": "https://github.com/mozilla/eslint-plugin-no-unsanitized/",
     "keywords": [


### PR DESCRIPTION
I'm not sure what requirements this project has for bumping eslint, but we noticed that the eslint dependency was lagging behind the eslint project itself when we were introducing [no-unsanitized in kibana](https://github.com/elastic/kibana/pull/16477), so I figured I'd open a PR to get the process started.

Note, bumping eslint required a change to `runHelper` to make sure it could pass what I assume are new default linting behaviors in eslint 4.  Let me know if you'd prefer a different solution than relying on the defaults.