### PR TITLE
move eslint to peer dependencies, loosen version requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
         "url": "https://github.com/mozilla/eslint-plugin-no-unsanitized/issues"
     },
     "devDependencies": {
-        "mocha": "^3.2.0"
-    },
-    "dependencies": {
+        "mocha": "^3.2.0",
         "eslint": "^4.16.0"
+    },
+    "peerDependencies": {
+        "eslint": ">=3"
     },
     "homepage": "https://github.com/mozilla/eslint-plugin-no-unsanitized/",
     "keywords": [


### PR DESCRIPTION
As recommended by the [eslint documentation](https://eslint.org/docs/developer-guide/shareable-configs#publishing-a-shareable-config), moves eslint to peerDependencies and uses >= 3 version specifier to allow users flexibility. Also adds eslint to dev dependencies as it is used by this project.