### PR TITLE
Improve performance of no-unsanitized/method

### DIFF
--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -13,10 +13,13 @@ const VALID_UNWRAPPERS = ["Sanitizer.unwrapSafeHTML", "unwrapSafeHTML"];
  *
  * @constructor
  * @param {Object} context ESLint configuration context
+ * @param {Object} defaultRuleChecks Default rules to merge with
+ * this.context
  *
  */
-function RuleHelper(context) {
+function RuleHelper(context, defaultRuleChecks) {
     this.context = context;
+    this.ruleChecks = this.combineRuleChecks(defaultRuleChecks);
 }
 
 RuleHelper.prototype = {
@@ -212,17 +215,14 @@ RuleHelper.prototype = {
     /**
      * Runs the checks against a CallExpression
      * @param {Object} node Call expression node
-     * @param {Object} defaultRuleChecks Default rules to merge with
-     * this.context
      * @returns {undefined} Does not return
      */
-    checkMethod(node, defaultRuleChecks) {
-        const ruleChecks = this.combineRuleChecks(defaultRuleChecks);
+    checkMethod(node) {
         const normalizeMethodCall = this.normalizeMethodCall(node.callee);
         const methodName = normalizeMethodCall.methodName;
 
-        if (ruleChecks.hasOwnProperty(methodName)) {
-            const ruleCheck = ruleChecks[methodName];
+        if (this.ruleChecks.hasOwnProperty(methodName)) {
+            const ruleCheck = this.ruleChecks[methodName];
             if (!Array.isArray(ruleCheck.properties)) {
                 this.context.report(node, `Method check requires properties array in eslint rule ${methodName}`);
                 return;
@@ -240,15 +240,11 @@ RuleHelper.prototype = {
     /**
      * Runs the checks against an assignment expression
      * @param {Object} node Assignment expression node
-     * @param {Object} defaultRuleChecks Default rules to merge with
-     * this.context
      * @returns {undefined} Does not return
      */
-    checkProperty(node, defaultRuleChecks) {
-        const ruleChecks = this.combineRuleChecks(defaultRuleChecks);
-
-        if (ruleChecks.hasOwnProperty(node.left.property.name)) {
-            const ruleCheck = ruleChecks[node.left.property.name];
+    checkProperty(node) {
+        if (this.ruleChecks.hasOwnProperty(node.left.property.name)) {
+            const ruleCheck = this.ruleChecks[node.left.property.name];
             if (!this.allowedExpression(node.right, ruleCheck.escape)) {
                 this.context.report(node, `Unsafe assignment to ${node.left.property.name}`);
             }

--- a/lib/rules/method.js
+++ b/lib/rules/method.js
@@ -54,7 +54,7 @@ function checkCallExpression(ruleHelper, callExpr, node) {
     case "Identifier":
     case "MemberExpression":
         if (callExpr.arguments.length > 0) {
-            ruleHelper.checkMethod(callExpr, defaultRuleChecks);
+            ruleHelper.checkMethod(callExpr);
         }
         break;
     case "AssignmentExpression":
@@ -93,9 +93,9 @@ module.exports = {
         ]*/
     },
     create(context) {
+        const ruleHelper = new RuleHelper(context, defaultRuleChecks);
         return {
             CallExpression(node) {
-                const ruleHelper = new RuleHelper(context);
                 checkCallExpression(ruleHelper, node, node.callee);
             }
         };

--- a/lib/rules/property.js
+++ b/lib/rules/property.js
@@ -39,7 +39,7 @@ module.exports = {
         ]*/
     },
     create(context) {
-        const ruleHelper = new RuleHelper(context);
+        const ruleHelper = new RuleHelper(context, defaultRuleChecks);
 
         // operators to not check, such as X.innerHTML *= 12; is likely very safe
         // This list explicitly doesn't check ["=", "+="] or any newer operators that have not been reviewed
@@ -60,7 +60,7 @@ module.exports = {
                         if (CHECK_REQUIRED_OPERATORS.indexOf(node.operator) === -1) {
                             ruleHelper.reportUnsupported(node, "Unexpected Assignment", "Unsupported Operator for AssignmentExpression");
                         }
-                        ruleHelper.checkProperty(node, defaultRuleChecks);
+                        ruleHelper.checkProperty(node);
                     }
                 }
             }


### PR DESCRIPTION
Currently no-unsanitized/method is creating a new RuleContext, and combining an array of rules for pretty much each CallExpression.

I think this can be avoided to help performance.

Using's ESLint TIMING=1 environment variable and running against mozilla-central, I saw no-unsanitized/method go from being in the top-ten rules at about 2.6 seconds to dropping completely out of the list to less than 1.5 seconds (unfortunately they don't report more than the top-ten).

