### PR TITLE
allow `import()` calls

### DIFF
--- a/lib/rules/method.js
+++ b/lib/rules/method.js
@@ -70,6 +70,7 @@ function checkCallExpression(ruleHelper, callExpr, node) {
     case "CallExpression":
     case "ThisExpression":
     case "NewExpression":
+    case "Import":
         break;
 
     // If we don't cater for this expression throw an error

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
         "url": "https://github.com/mozilla/eslint-plugin-no-unsanitized/issues"
     },
     "devDependencies": {
-        "mocha": "^3.2.0",
-        "eslint": "^4.16.0"
+        "babel-eslint": "^8.2.3",
+        "eslint": "^4.16.0",
+        "mocha": "^3.2.0"
     },
     "peerDependencies": {
         "eslint": ">=3"
@@ -31,7 +32,7 @@
         "type": "git",
         "url": "https://github.com/mozilla/eslint-plugin-no-unsanitized/issues"
     },
-    "scripts":{
+    "scripts": {
         "test": "./node_modules/.bin/mocha tests/rules/",
         "lint": "./node_modules/.bin/eslint index.js lib/*.js lib/**/*.js tests/**/*.js"
     }

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -146,7 +146,13 @@ eslintTester.run("method", rule, {
                     }
                 }
             ]
-        }
+        },
+
+        // Issue 83: Support import() expressions as parsed by babel-eslint
+        {
+            code: "import('lodash')",
+            parser: "babel-eslint"
+        },
     ],
 
     // Examples of code that should trigger the rule


### PR DESCRIPTION
Fixes #83

As @mozfreddyb pointed out, the spec seems to describe a node type of `ImportCall`, but all of the parsers available at http://astexplorer.net/ parse `import()` as a `CallExpression` with a callee of type `Import`, so I've used that type for the methods whitelist.

Hope that's alright, it works great.