### PR TITLE
- Enhancement: Avoid need for `plugins` when using `extends`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,10 @@ $ npm install --save-dev eslint-plugin-no-unsanitized
 
 ## Usage
 
-In your eslint.json file enable this rule with the following:
+In your `.eslintrc.json` file enable this rule with the following:
 
 ```
 {
-
-    "plugins": ["no-unsanitized"],
     "extends": ["plugin:no-unsanitized/DOM"]
 }
 ```

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = {
     },
     configs: {
         DOM: {
+            plugins: ["no-unsanitized"],
             rules: {
                 "no-unsanitized/property": [
                     "error",


### PR DESCRIPTION
You can see at https://eslint.org/docs/6.0.0/developer-guide/working-with-plugins#configs-in-plugins that `plugins` can be included within `configs` (we do so in various linting projects, e.g., `eslint-plugin-jsdoc`).

I also fixed mention of the config file which was misspelled (see https://eslint.org/docs/user-guide/configuring#configuration-file-formats ).

