### PR TITLE
Add meta.type "problem"

### DIFF
--- a/lib/rules/method.js
+++ b/lib/rules/method.js
@@ -103,6 +103,7 @@ function checkCallExpression(ruleHelper, callExpr, node) {
 
 module.exports = {
     meta: {
+        type: "problem",
         docs: {
             description: "ESLint rule to disallow unsanitized method calls",
             category: "possible-errors",

--- a/lib/rules/property.js
+++ b/lib/rules/property.js
@@ -25,6 +25,7 @@ const defaultRuleChecks = {
 
 module.exports = {
     meta: {
+        type: "problem",
         docs: {
             description: "ESLint rule to disallow unsanitized property assignment",
             category: "possible-errors",


### PR DESCRIPTION
- Add `meta: {type: "problem"}` to `method` and `property` rules

For fixable rules, this would mean it would be usable with `--fix-type`: https://eslint.org/docs/user-guide/command-line-interface#fix-type . But I'm personally planning to take advantage of `meta.type` with my badge-making project https://github.com/brettz9/eslint-formatter-badger when ready, so that linting counts can be grouped by type. Anyways, it shouldn't hurt to specify the nature of the rule.

While there is inevitably some ambiguity (e.g., is the use of the rule *always* a problem?), this ambiguity is I think present with pretty much any linting rule, so I think the basic idea is that this can be more serious than a "suggestion" and is not of course just "layout", the other possibility.