### PR TITLE
Special handling AssignmentExpression with a MemberExpression on the right node (fixes #124)

### DIFF
--- a/lib/rules/method.js
+++ b/lib/rules/method.js
@@ -62,14 +62,20 @@ function checkCallExpression(ruleHelper, callExpr, node) {
             ruleHelper.checkMethod(callExpr);
         }
         break;
+
     case "AssignmentExpression":
+        if (node.right.type === "MemberExpression") {
+            const newCallExpr = Object.assign({}, callExpr);
+            newCallExpr.callee = node.right;
+            checkCallExpression(ruleHelper, newCallExpr, node.right);
+            break;
+        }
         checkCallExpression(ruleHelper, callExpr, node.right);
         break;
 
     case "Import":
         ruleHelper.checkMethod(callExpr);
         break;
-
 
     case "SequenceExpression": {
         // the return value of a SequenceExpression is the last expression.

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -211,6 +211,14 @@ eslintTester.run("method", rule, {
             code: "async () => (await TheRuleDoesntKnowWhatIsBeingReturnedHere())('afterend', blah);",
             parserOptions: { ecmaVersion: 2020 }
         },
+        { // Regression test for #124, make sure we don't raise an "Unexpected Callee" error.
+            code: "(e = this.n[n.i])(i, r)",
+            parserOptions: { ecmaVersion: 6 },
+        },
+        { // Regression test for #124, make sure we go deeper into validating the AssignmentExpression.
+            code: "(e = node.insertAdjacentHTML('beforebegin', '<s>safe</s>'))()",
+            parserOptions: { ecmaVersion: 6 },
+        },
     ],
 
     // Examples of code that should trigger the rule
@@ -494,6 +502,26 @@ eslintTester.run("method", rule, {
                     type: "CallExpression"
                 }
             ]
-        }
+        },
+        { // AssignmentExpression, ensure we are detecting the pattern from the right part - Regression test for #124
+            code: "(e = node.insertAdjacentHTML)('beforebegin', evil)",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Unsafe call to node.insertAdjacentHTML for argument 1",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        { // Regression test for #124, make sure we go deeper and detect the unsafe pattern
+            code: "(e = node.insertAdjacentHTML('beforebegin', evil))()",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Unsafe call to node.insertAdjacentHTML for argument 1",
+                    type: "CallExpression"
+                }
+            ]
+        },
     ]
 });


### PR DESCRIPTION
In this pull requests there are:
- a couple of additional test cases to explicitly cover the issue describe in #124 
- a draft for a proposed approach to deal with this scenario (to be evaluated and discussed as part of this pull request):
  - while validating a CallExpression, if we do have an AssignmentExpression as the callee node 
  - check if the AssignmentExpression has a MemberExpression on the right and, if it does, validate a fake call expression that does have the memberExpression as the callee node. 