### PR TITLE
Adds Typescript support to eslint-plugin-no-unsanitized

### DIFF
--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -74,7 +74,11 @@ RuleHelper.prototype = {
         } else if (expression.type === "BinaryExpression") {
             allowed = ((this.allowedExpression(expression.left, escapeObject))
             && (this.allowedExpression(expression.right, escapeObject)));
-        } else {
+        } else if (expression.type === "TSAsExpression") {
+            // TSAsExpressions contain the raw javascript value in 'expression'
+            allowed = this.allowedExpression(expression.expression, escapeObject);
+        }
+        else {
             // everything that doesn't match is unsafe:
             allowed = false;
         }

--- a/lib/rules/method.js
+++ b/lib/rules/method.js
@@ -63,6 +63,13 @@ function checkCallExpression(ruleHelper, callExpr, node) {
         }
         break;
 
+    case "TSNonNullExpression": {
+        const newCallExpr = Object.assign({}, callExpr);
+        newCallExpr.callee = node.expression;
+        checkCallExpression(ruleHelper, newCallExpr, node.expression);
+        break;
+    }
+
     case "AssignmentExpression":
         if (node.right.type === "MemberExpression") {
             const newCallExpr = Object.assign({}, callExpr);
@@ -90,6 +97,9 @@ function checkCallExpression(ruleHelper, callExpr, node) {
         break;
     }
 
+    case "TSAsExpression":
+        break;
+
     // those are fine:
     case "LogicalExpression": // Should we scan these? issue #62.
     case "ConditionalExpression":
@@ -99,6 +109,7 @@ function checkCallExpression(ruleHelper, callExpr, node) {
     case "CallExpression":
     case "ThisExpression":
     case "NewExpression":
+    case "TSTypeAssertion":
     case "AwaitExpression": // see issue #122
         break;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-no-unsanitized",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -789,6 +789,98 @@
             "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
             "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
             "dev": true
+        },
+        "@types/eslint-visitor-keys": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+            "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+            "dev": true
+        },
+        "@types/json-schema": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
+            "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+            "dev": true
+        },
+        "@typescript-eslint/experimental-utils": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.7.1.tgz",
+            "integrity": "sha512-TqE97pv7HrqWcGJbLbZt1v59tcqsSVpWTOf1AqrWK7n8nok2sGgVtYRuGXeNeLw3wXlLEbY1MKP3saB2HsO/Ng==",
+            "dev": true,
+            "requires": {
+                "@types/json-schema": "^7.0.3",
+                "@typescript-eslint/types": "3.7.1",
+                "@typescript-eslint/typescript-estree": "3.7.1",
+                "eslint-scope": "^5.0.0",
+                "eslint-utils": "^2.0.0"
+            },
+            "dependencies": {
+                "eslint-scope": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+                    "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+                    "dev": true,
+                    "requires": {
+                        "esrecurse": "^4.1.0",
+                        "estraverse": "^4.1.1"
+                    }
+                }
+            }
+        },
+        "@typescript-eslint/parser": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.7.1.tgz",
+            "integrity": "sha512-W4QV/gXvfIsccN8225784LNOorcm7ch68Fi3V4Wg7gmkWSQRKevO4RrRqWo6N/Z/myK1QAiGgeaXN57m+R/8iQ==",
+            "dev": true,
+            "requires": {
+                "@types/eslint-visitor-keys": "^1.0.0",
+                "@typescript-eslint/experimental-utils": "3.7.1",
+                "@typescript-eslint/types": "3.7.1",
+                "@typescript-eslint/typescript-estree": "3.7.1",
+                "eslint-visitor-keys": "^1.1.0"
+            }
+        },
+        "@typescript-eslint/types": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.7.1.tgz",
+            "integrity": "sha512-PZe8twm5Z4b61jt7GAQDor6KiMhgPgf4XmUb9zdrwTbgtC/Sj29gXP1dws9yEn4+aJeyXrjsD9XN7AWFhmnUfg==",
+            "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.7.1.tgz",
+            "integrity": "sha512-m97vNZkI08dunYOr2lVZOHoyfpqRs0KDpd6qkGaIcLGhQ2WPtgHOd/eVbsJZ0VYCQvupKrObAGTOvk3tfpybYA==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "3.7.1",
+                "@typescript-eslint/visitor-keys": "3.7.1",
+                "debug": "^4.1.1",
+                "glob": "^7.1.6",
+                "is-glob": "^4.0.1",
+                "lodash": "^4.17.15",
+                "semver": "^7.3.2",
+                "tsutils": "^3.17.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
+            }
+        },
+        "@typescript-eslint/visitor-keys": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.7.1.tgz",
+            "integrity": "sha512-xn22sQbEya+Utj2IqJHGLA3i1jDzR43RzWupxojbSWnj3nnPLavaQmWe5utw03CwYao3r00qzXfgJMGNkrzrAA==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^1.1.0"
+            }
         },
         "acorn": {
             "version": "7.2.0",
@@ -3130,6 +3222,15 @@
             "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
             "dev": true
         },
+        "tsutils": {
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+            "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.8.1"
+            }
+        },
         "type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3153,6 +3254,12 @@
             "requires": {
                 "is-typedarray": "^1.0.0"
             }
+        },
+        "typescript": {
+            "version": "3.9.7",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+            "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+            "dev": true
         },
         "uri-js": {
             "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
         "url": "https://github.com/mozilla/eslint-plugin-no-unsanitized/issues"
     },
     "devDependencies": {
+        "@typescript-eslint/parser": "^3.7.1",
         "babel-eslint": "^8.2.6",
         "eslint": "^7.1.0",
         "mocha": "^7.2.0",
-        "nyc": "^15.1.0"
+        "nyc": "^15.1.0",
+        "typescript": "^3.9.7"
     },
     "peerDependencies": {
         "eslint": "^5 || ^6 || ^7"

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -12,6 +12,7 @@ const rule = require("../../lib/rules/method");
 const RuleTester = require("eslint").RuleTester;
 
 const PATH_TO_BABEL_ESLINT = `${process.cwd()}/node_modules/babel-eslint/`;
+const PATH_TO_TYPESCRIPT_ESLINT = `${process.cwd()}/node_modules/@typescript-eslint/parser/`;
 
 //------------------------------------------------------------------------------
 // Tests
@@ -219,6 +220,32 @@ eslintTester.run("method", rule, {
             code: "(e = node.insertAdjacentHTML('beforebegin', '<s>safe</s>'))()",
             parserOptions: { ecmaVersion: 6 },
         },
+
+        // Typescript support tests
+        {
+            code: "node.insertAdjacentHTML('beforebegin', (5 as string));",
+            parser: PATH_TO_TYPESCRIPT_ESLINT,
+            parserOptions: {
+                ecmaVersion: 2018,
+                sourceType: "module",
+            },
+        },
+        {
+            code: "node!.insertAdjacentHTML('beforebegin', 'raw string');",
+            parser: PATH_TO_TYPESCRIPT_ESLINT,
+            parserOptions: {
+                ecmaVersion: 2018,
+                sourceType: "module",
+            }
+        },
+        {
+            code: "node!().insertAdjacentHTML('beforebegin', 'raw string');",
+            parser: PATH_TO_TYPESCRIPT_ESLINT,
+            parserOptions: {
+                ecmaVersion: 2018,
+                sourceType: "module",
+            }
+        },
     ],
 
     // Examples of code that should trigger the rule
@@ -227,7 +254,8 @@ eslintTester.run("method", rule, {
          * The strings are optimized for SEO and understandability.
          * The developer can search for them and will find this MDN article:
          *  https://developer.mozilla.org/en-US/Firefox_OS/Security/Security_Automation
-         */
+         */ 
+
 
         // insertAdjacentHTML examples
         {
@@ -531,6 +559,52 @@ eslintTester.run("method", rule, {
                     type: "Literal"
                 }
             ]
-        }
+        },
+
+        // Typescript test cases
+        //
+        // Null coalescing operator
+        {
+            code: "node!().insertAdjacentHTML('beforebegin', htmlString);",
+            parser: PATH_TO_TYPESCRIPT_ESLINT,
+            parserOptions: {
+                ecmaVersion: 2018,
+                sourceType: "module",
+            },
+            errors: [
+                {
+                    message: "Unsafe call to node!().insertAdjacentHTML for argument 1",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "node!.insertAdjacentHTML('beforebegin', htmlString);",
+            parser: PATH_TO_TYPESCRIPT_ESLINT,
+            parserOptions: {
+                ecmaVersion: 2018,
+                sourceType: "module",
+            },
+            errors: [
+                {
+                    message: "Unsafe call to node!.insertAdjacentHTML for argument 1",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "(x as HTMLElement).insertAdjacentHTML('beforebegin', htmlString)",
+            parser: PATH_TO_TYPESCRIPT_ESLINT,
+            parserOptions: {
+                ecmaVersion: 2018,
+                sourceType: "module",
+            },
+            errors: [
+                {
+                    message: "Unsafe call to x as HTMLElement.insertAdjacentHTML for argument 1",
+                    type: "CallExpression"
+                }
+            ]
+        },
     ]
 });

--- a/tests/rules/property.js
+++ b/tests/rules/property.js
@@ -11,6 +11,8 @@
 const rule = require("../../lib/rules/property");
 const RuleTester = require("eslint").RuleTester;
 
+const PATH_TO_TYPESCRIPT_ESLINT = `${process.cwd()}/node_modules/@typescript-eslint/parser/`;
+
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
@@ -145,7 +147,47 @@ eslintTester.run("property", rule, {
             ]
         },
 
-
+        // Typescript support valid cases
+        // raw strings can be assigned to innerHTML
+        {
+            code: "(options as HTMLElement).innerHTML = '<s>safe</s>';",
+            parser: PATH_TO_TYPESCRIPT_ESLINT,
+            parserOptions: {
+                ecmaVersion: 2018,
+                sourceType: "module",
+            }
+        },
+        {
+            code: "(<HTMLElement>items[i](args)).innerHTML = 'rawstring';",
+            parser: PATH_TO_TYPESCRIPT_ESLINT,
+            parserOptions: {
+                ecmaVersion: 2018,
+                sourceType: "module",
+            }
+        },
+        {
+            code: "lol.innerHTML = (5 as string);",
+            parser: PATH_TO_TYPESCRIPT_ESLINT,
+            parserOptions: {
+                ecmaVersion: 2018,
+                sourceType: "module",
+            },
+        },
+        {
+            code: "node!.innerHTML = DOMPurify.sanitize(evil);",
+            parser: PATH_TO_TYPESCRIPT_ESLINT,
+            parserOptions: {
+                ecmaVersion: 2018,
+                sourceType: "module",
+            },
+            options: [
+                {
+                    escape: {
+                        methods: ["DOMPurify.sanitize"]
+                    }
+                }
+            ]
+        },
     ],
 
     // Examples of code that should trigger the rule
@@ -307,7 +349,6 @@ eslintTester.run("property", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
 
-
         // the previous override for manual review and legacy code is now invalid
         {
             code: "g.innerHTML = potentiallyUnsafe; // a=legacy, bug 1155131",
@@ -330,5 +371,48 @@ eslintTester.run("property", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
 
+        // Typescript support cases
+        {
+            code: "x!().innerHTML = htmlString",
+            parser: PATH_TO_TYPESCRIPT_ESLINT,
+            parserOptions: {
+                ecmaVersion: 2018,
+                sourceType: "module",
+            },
+            errors: [
+                {
+                    message: "Unsafe assignment to innerHTML",
+                    type: "AssignmentExpression"
+                }
+            ]
+        },
+        {
+            code: "(x as HTMLElement).innerHTML = htmlString",
+            parser: PATH_TO_TYPESCRIPT_ESLINT,
+            parserOptions: {
+                ecmaVersion: 2018,
+                sourceType: "module",
+            },
+            errors: [
+                {
+                    message: "Unsafe assignment to innerHTML",
+                    type: "AssignmentExpression"
+                }
+            ]
+        },
+        {
+            code: "lol.innerHTML = (foo as string);",
+            parser: PATH_TO_TYPESCRIPT_ESLINT,
+            parserOptions: {
+                ecmaVersion: 2018,
+                sourceType: "module",
+            },
+            errors: [
+                {
+                    message: "Unsafe assignment to innerHTML",
+                    type: "AssignmentExpression"
+                }
+            ]
+        },
     ]
 });


### PR DESCRIPTION
This is one of the two operators required for adding typescript
support to eslint-plugin-no-unsanitized

Adds support for TSAsExpression and TSTypeAssertion nodes.  These are
noops.

Adds test cases to method.js to ensure the new behavior is not broken.