### PR TITLE
Add "files" list to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     ],
     "license": "MPL-2.0",
     "main": "index.js",
+    "files": ["index.js", "lib"],
     "repository": {
         "type": "git",
         "url": "https://github.com/mozilla/eslint-plugin-no-unsanitized/issues"


### PR DESCRIPTION
Only publish `index.js` and the `lib` folder in the public npm package.

fixes #130