### PR TITLE
Update babel requirements and deal with newer 'import' parsing

### DIFF
--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -127,7 +127,7 @@ RuleHelper.prototype = {
             methodName = "import";
             break;
         default:
-            this.reportUnsupported(node, "Unexpected callable", `unexpected ${node.type} in normalizeMethodName`);
+            this.reportUnsupported(node, "Unexpected callable", `unexpected ${node.type} in normalizeMethodCall`);
         }
         return {
             objectName,

--- a/lib/rules/method.js
+++ b/lib/rules/method.js
@@ -48,6 +48,18 @@ const defaultRuleChecks = {
 };
 
 /**
+ * On newer parsers, `import(foo)` gets parsed as a keyword.
+ * @param {Object} ruleHelper a RuleHelper instance
+ * @param {Object} importExpr The ImportExpression we triggered on
+ * @returns {undefined} Does not return
+ */
+function checkImport(ruleHelper, importExpr) {
+    const fakeCall = {callee: {type: "Import"}, arguments: [importExpr.source]};
+    Object.assign(fakeCall, importExpr);
+    ruleHelper.checkMethod(fakeCall);
+}
+
+/**
  * Run ruleHelper.checkMethod for all but irrelevant callees (FunctionExpression, etc.)
  * @param {Object} ruleHelper a RuleHelper instance
  * @param {Object} callExpr The CallExpression we triggered on
@@ -139,7 +151,10 @@ module.exports = {
         return {
             CallExpression(node) {
                 checkCallExpression(ruleHelper, node, node.callee);
-            }
+            },
+            ImportExpression(node) {
+                checkImport(ruleHelper, node);
+            },
         };
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
     "requires": true,
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-            "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+            "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "7.0.0-beta.44"
+                "@babel/highlight": "^7.10.4"
             }
         },
         "@babel/core": {
@@ -161,36 +161,34 @@
             }
         },
         "@babel/generator": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
-            "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+            "version": "7.11.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+            "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0-beta.44",
+                "@babel/types": "^7.11.5",
                 "jsesc": "^2.5.1",
-                "lodash": "^4.2.0",
-                "source-map": "^0.5.0",
-                "trim-right": "^1.0.1"
+                "source-map": "^0.5.0"
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
-            "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+            "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "7.0.0-beta.44",
-                "@babel/template": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44"
+                "@babel/helper-get-function-arity": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
-            "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+            "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0-beta.44"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-member-expression-to-functions": {
@@ -523,12 +521,12 @@
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
-            "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+            "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0-beta.44"
+                "@babel/types": "^7.11.0"
             }
         },
         "@babel/helper-validator-identifier": {
@@ -666,14 +664,22 @@
             }
         },
         "@babel/highlight": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-            "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+            "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
             "dev": true,
             "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
                 "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.0"
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+                    "dev": true
+                }
             }
         },
         "@babel/parser": {
@@ -683,44 +689,75 @@
             "dev": true
         },
         "@babel/template": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
-            "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+            "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44",
-                "babylon": "7.0.0-beta.44",
-                "lodash": "^4.2.0"
+                "@babel/code-frame": "^7.10.4",
+                "@babel/parser": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            },
+            "dependencies": {
+                "@babel/parser": {
+                    "version": "7.11.5",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+                    "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+                    "dev": true
+                }
             }
         },
         "@babel/traverse": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
-            "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+            "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.44",
-                "@babel/generator": "7.0.0-beta.44",
-                "@babel/helper-function-name": "7.0.0-beta.44",
-                "@babel/helper-split-export-declaration": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44",
-                "babylon": "7.0.0-beta.44",
-                "debug": "^3.1.0",
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.11.5",
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/parser": "^7.11.5",
+                "@babel/types": "^7.11.5",
+                "debug": "^4.1.0",
                 "globals": "^11.1.0",
-                "invariant": "^2.2.0",
-                "lodash": "^4.2.0"
+                "lodash": "^4.17.19"
+            },
+            "dependencies": {
+                "@babel/parser": {
+                    "version": "7.11.5",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+                    "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                    "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                }
             }
         },
         "@babel/types": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-            "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+            "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
             "dev": true,
             "requires": {
-                "esutils": "^2.0.2",
-                "lodash": "^4.2.0",
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
                 "to-fast-properties": "^2.0.0"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+                    "dev": true
+                }
             }
         },
         "@istanbuljs/load-nyc-config": {
@@ -995,24 +1032,18 @@
             "dev": true
         },
         "babel-eslint": {
-            "version": "8.2.6",
-            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
-            "integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+            "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.44",
-                "@babel/traverse": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44",
-                "babylon": "7.0.0-beta.44",
-                "eslint-scope": "3.7.1",
-                "eslint-visitor-keys": "^1.0.0"
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.7.0",
+                "@babel/traverse": "^7.7.0",
+                "@babel/types": "^7.7.0",
+                "eslint-visitor-keys": "^1.0.0",
+                "resolve": "^1.12.0"
             }
-        },
-        "babylon": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-            "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-            "dev": true
         },
         "balanced-match": {
             "version": "1.0.0",
@@ -1488,16 +1519,6 @@
                 }
             }
         },
-        "eslint-scope": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-            "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-            "dev": true,
-            "requires": {
-                "esrecurse": "^4.1.0",
-                "estraverse": "^4.1.1"
-            }
-        },
         "eslint-utils": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
@@ -1939,15 +1960,6 @@
                 }
             }
         },
-        "invariant": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-            "dev": true,
-            "requires": {
-                "loose-envify": "^1.0.0"
-            }
-        },
         "is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2172,9 +2184,9 @@
             }
         },
         "js-tokens": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true
         },
         "js-yaml": {
@@ -2253,15 +2265,6 @@
             "dev": true,
             "requires": {
                 "chalk": "^2.4.2"
-            }
-        },
-        "loose-envify": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
-            "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
             }
         },
         "make-dir": {
@@ -3209,12 +3212,6 @@
             "requires": {
                 "is-number": "^7.0.0"
             }
-        },
-        "trim-right": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-            "dev": true
         },
         "tslib": {
             "version": "1.13.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     },
     "devDependencies": {
         "@typescript-eslint/parser": "^3.7.1",
-        "babel-eslint": "^8.2.6",
+        "babel-eslint": "^10.1.0",
         "eslint": "^7.1.0",
         "mocha": "^7.2.0",
         "nyc": "^15.1.0",

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -411,7 +411,7 @@ eslintTester.run("method", rule, {
             errors: [
                 {
                     message: "Unsafe call to import for argument 0",
-                    type: "CallExpression"
+                    type: "ImportExpression"
                 }
             ]
         },


### PR DESCRIPTION
I need this for the patch for #147 , as it needs a more modern babel. Other parsers (e.g. acorn as used on https://astexplorer.net/ ) also use the `ImportExpression` node type.