### PR TITLE
Trace variables back to find allow-able expression (fix #167)

### DIFF
--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -231,8 +231,8 @@ RuleHelper.prototype = {
         let matched = false;
 
         // Allow methods named "import":
-        if (normalizedMethodCall.methodName == "import"
-            && node.callee && node.callee.type == "MemberExpression") {
+        if (normalizedMethodCall.methodName === "import"
+            && node.callee && node.callee.type === "MemberExpression") {
             return false;
         }
 

--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -85,6 +85,55 @@ RuleHelper.prototype = {
             allowed = this.allowedExpression(expression.expression, escapeObject);
         } else if (Array.isArray(expression)) {
             allowed = expression.every((e) => this.allowedExpression(e, escapeObject));
+        } else if (expression.type == "Identifier") {
+            // find declared variables and see which are literals
+            const scope = this.context.getScope(expression);
+            const variableInfo = scope.set.get(expression.name);
+
+            // let's see if this variable is allowed, by tracing it back through the code
+            if (variableInfo) {
+                // look if the var was defined as allowable
+                let definedAsAllowed = false;
+                for (const def of variableInfo.defs) {
+                    if (def.node.type === "VariableDeclarator") {
+                        // the `init` property carries the right-hand side of the variable definition:
+                        const varInitAs = def.node.init;
+                        if (!this.allowedExpression(varInitAs, escapeObject)) {
+                            // if one variable definition is considered unsafe, all are.
+                            // NB: order of definition is unclear. See issue #168.
+                            definedAsAllowed = false;
+                            break;
+                        }
+
+                        // keep iterating through other definitions.
+                        definedAsAllowed = true;
+
+                    }
+                }
+                if (definedAsAllowed) {
+                    // the variable was declared as a safe value (e.g., literal)
+                    // now inspect writing references to that variable
+                    let allWritingRefsAllowed = false;
+                    for (const ref of variableInfo.references) {
+                        // only look into writing references
+                        if (ref.isWrite()) {
+                            const writeExpr = ref.writeExpr;
+
+                            // if one is unsafe we'll consider all unsafe.
+                            // this is because code occurring doesn't guarantee it being executed
+                            // due to dynamic behavior if-conditions and such
+                            if (!this.allowedExpression(writeExpr, escapeObject)) {
+                                allWritingRefsAllowed = false;
+                                break;
+                            }
+                            allWritingRefsAllowed = true;
+                        }
+                    }
+
+                    // allow this variable, because all writing references to it were allowed.
+                    allowed = allWritingRefsAllowed;
+                }
+            }
         }
         else {
             // everything that doesn't match is unsafe:

--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -25,18 +25,19 @@ function RuleHelper(context, defaultRuleChecks) {
 RuleHelper.prototype = {
     /**
      * Returns true if the expression contains allowed syntax, otherwise false.
-     * For Template Strings with interpolation (e.g. |`${foo}`|) and
-     * Binary Expressions (e.g. |foo+bar|), the function will look into the expression
-     * recursively.
-     * For testing and development, I recommend looking at example code and its syntax tree.
-     * Using the Esprima Demo, for example: http://esprima.org/demo/parse.html
      *
-     * @constructor
+     * The function will be called recursively for Template Strings with interpolation
+     * (e.g. `Hello ${name}`), Binary Expressions (e.g. |foo+bar|), and more.
+     *
      * @param {Object} expression Checks whether this node is an allowed expression.
      * @param {Object} escapeObject contains keys "methods" and "taggedTemplates" which are arrays of strings
      *                              of matching escaping function names.
+     * @param {Object} details Additional linter violation state information, in case this function was called
+     *                         recursively.
+     * @returns {boolean} Returns whether the expression is allowed.
+     *
      */
-    allowedExpression(expression, escapeObject) {
+    allowedExpression(expression, escapeObject, details) {
         if (!escapeObject) {
             escapeObject = {};
         }
@@ -66,7 +67,7 @@ RuleHelper.prototype = {
             // check for ${..} expressions
             for (let e = 0; e < expression.expressions.length; e++) {
                 const templateExpression = expression.expressions[e];
-                if (!this.allowedExpression(templateExpression, escapeObject)) {
+                if (!this.allowedExpression(templateExpression, escapeObject, details)) {
                     allowed = false;
                     break;
                 }
@@ -76,16 +77,16 @@ RuleHelper.prototype = {
         } else if (expression.type === "CallExpression") {
             allowed = this.isAllowedCallExpression(expression.callee, escapeObject.methods || VALID_UNWRAPPERS);
         } else if (expression.type === "BinaryExpression") {
-            allowed = ((this.allowedExpression(expression.left, escapeObject))
-            && (this.allowedExpression(expression.right, escapeObject)));
+            allowed = ((this.allowedExpression(expression.left, escapeObject, details))
+            && (this.allowedExpression(expression.right, escapeObject, details)));
         } else if (expression.type === "TSAsExpression") {
             // TSAsExpressions contain the raw javascript value in 'expression'
-            allowed = this.allowedExpression(expression.expression, escapeObject);
+            allowed = this.allowedExpression(expression.expression, escapeObject, details);
         } else if (expression.type === "TypeCastExpression") {
-            allowed = this.allowedExpression(expression.expression, escapeObject);
+            allowed = this.allowedExpression(expression.expression, escapeObject, details);
         } else if (Array.isArray(expression)) {
-            allowed = expression.every((e) => this.allowedExpression(e, escapeObject));
-        } else if (expression.type == "Identifier") {
+            allowed = expression.every((e) => this.allowedExpression(e, escapeObject, details));
+        } else if (expression.type === "Identifier") {
             // find declared variables and see which are literals
             const scope = this.context.getScope(expression);
             const variableInfo = scope.set.get(expression.name);
@@ -98,16 +99,19 @@ RuleHelper.prototype = {
                     if (def.node.type === "VariableDeclarator") {
                         // the `init` property carries the right-hand side of the variable definition:
                         const varInitAs = def.node.init;
-                        if (!this.allowedExpression(varInitAs, escapeObject)) {
+                        if (!this.allowedExpression(varInitAs, escapeObject, details)) {
                             // if one variable definition is considered unsafe, all are.
                             // NB: order of definition is unclear. See issue #168.
+                            if (!details.message) {
+                                const {line, column} = varInitAs.loc.start;
+                                details.message = `Variable '${expression.name}' initialized with unsafe value at ${line}:${column}`;
+                            }
                             definedAsAllowed = false;
                             break;
                         }
 
                         // keep iterating through other definitions.
                         definedAsAllowed = true;
-
                     }
                 }
                 if (definedAsAllowed) {
@@ -122,7 +126,11 @@ RuleHelper.prototype = {
                             // if one is unsafe we'll consider all unsafe.
                             // this is because code occurring doesn't guarantee it being executed
                             // due to dynamic behavior if-conditions and such
-                            if (!this.allowedExpression(writeExpr, escapeObject)) {
+                            if (!this.allowedExpression(writeExpr, escapeObject, details)) {
+                                if (!details.message) {
+                                    const {line, column} = writeExpr.loc.start;
+                                    details.message = `Variable '${expression.name}' reassigned with unsafe value at ${line}:${column}`;
+                                }
                                 allWritingRefsAllowed = false;
                                 break;
                             }
@@ -307,8 +315,15 @@ RuleHelper.prototype = {
             }
             ruleCheck.properties.forEach((propertyId) => {
                 const argument = node.arguments[propertyId];
+                const details = {};
                 if (this.shouldCheckMethodCall(node, ruleCheck.objectMatches)
-                    && !this.allowedExpression(argument, ruleCheck.escape)) {
+                    && !this.allowedExpression(argument, ruleCheck.escape, details)) {
+                    // Include the additional details if available (e.g. name of a disallowed variable
+                    // and the position of the expression that made it disallowed).
+                    if (details.message) {
+                        this.context.report(node, `Unsafe call to ${this.getCodeName(node.callee)} for argument ${propertyId} (${details.message})`);
+                        return;
+                    }
                     this.context.report(node, `Unsafe call to ${this.getCodeName(node.callee)} for argument ${propertyId}`);
                 }
             });
@@ -323,7 +338,14 @@ RuleHelper.prototype = {
     checkProperty(node) {
         if (Object.prototype.hasOwnProperty.call(this.ruleChecks, node.left.property.name)) {
             const ruleCheck = this.ruleChecks[node.left.property.name];
-            if (!this.allowedExpression(node.right, ruleCheck.escape)) {
+            const details = {};
+            if (!this.allowedExpression(node.right, ruleCheck.escape, details)) {
+                // Include the additional details if available (e.g. name of a disallowed variable
+                // and the position of the expression that made it disallowed).
+                if (details.message) {
+                    this.context.report(node, `Unsafe assignment to ${node.left.property.name} (${details.message})`);
+                    return;
+                }
                 this.context.report(node, `Unsafe assignment to ${node.left.property.name}`);
             }
         }

--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -130,9 +130,16 @@ RuleHelper.prototype = {
         let definedAsAllowed = false;
         for (const def of variableInfo.defs) {
             if (def.node.type !== "VariableDeclarator") {
-                // What else could it be..
-                const {line, column} = def.node;
-                details.message = `Variable '${expression.name}' initialized with unknown declaration at ${line}:${column}`;
+                // identifier wasn't declared as a variable
+                // e.g., it shows up as a parameter to an
+                // ArrowFunctionExpression, FunctionDeclaration or FunctionExpression
+                const {line, column} = def.node.loc.start;
+                if ((def.node.type === "FunctionDeclaration") || (def.node.type == "ArrowFunctionExpression") || (def.node.type === "FunctionExpression"))
+                {
+                    details.message = `Variable '${expression.name}' declared as function parameter, which is considered unsafe. '${def.node.type}' at ${line}:${column}`;
+                } else {
+                    details.message = `Variable '${expression.name}' initialized with unknown declaration '${def.node.type}' at ${line}:${column}`;
+                }
                 definedAsAllowed = false;
                 break;
             }

--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -87,71 +87,103 @@ RuleHelper.prototype = {
         } else if (Array.isArray(expression)) {
             allowed = expression.every((e) => this.allowedExpression(e, escapeObject, details));
         } else if (expression.type === "Identifier") {
-            // find declared variables and see which are literals
-            const scope = this.context.getScope(expression);
-            const variableInfo = scope.set.get(expression.name);
-
-            // let's see if this variable is allowed, by tracing it back through the code
-            if (variableInfo) {
-                // look if the var was defined as allowable
-                let definedAsAllowed = false;
-                for (const def of variableInfo.defs) {
-                    if (def.node.type === "VariableDeclarator") {
-                        if ((def.kind !== "let") && (def.kind !== "const")) {
-                            // We do not allow for identifiers declared with "var", as they can be overridden in a
-                            // way that is hard for us to follow (e.g., assignments to globalThis[theirNameAsString]).
-                            continue;
-                        }
-
-                        // the `init` property carries the right-hand side of the variable definition:
-                        const varInitAs = def.node.init;
-                        if (!this.allowedExpression(varInitAs, escapeObject, details)) {
-                            // if one variable definition is considered unsafe, all are.
-                            // NB: order of definition is unclear. See issue #168.
-                            if (!details.message) {
-                                const {line, column} = varInitAs.loc.start;
-                                details.message = `Variable '${expression.name}' initialized with unsafe value at ${line}:${column}`;
-                            }
-                            definedAsAllowed = false;
-                            break;
-                        }
-
-                        // keep iterating through other definitions.
-                        definedAsAllowed = true;
-                    }
-                }
-                if (definedAsAllowed) {
-                    // the variable was declared as a safe value (e.g., literal)
-                    // now inspect writing references to that variable
-                    let allWritingRefsAllowed = false;
-                    for (const ref of variableInfo.references) {
-                        // only look into writing references
-                        if (ref.isWrite()) {
-                            const writeExpr = ref.writeExpr;
-
-                            // if one is unsafe we'll consider all unsafe.
-                            // this is because code occurring doesn't guarantee it being executed
-                            // due to dynamic behavior if-conditions and such
-                            if (!this.allowedExpression(writeExpr, escapeObject, details)) {
-                                if (!details.message) {
-                                    const {line, column} = writeExpr.loc.start;
-                                    details.message = `Variable '${expression.name}' reassigned with unsafe value at ${line}:${column}`;
-                                }
-                                allWritingRefsAllowed = false;
-                                break;
-                            }
-                            allWritingRefsAllowed = true;
-                        }
-                    }
-
-                    // allow this variable, because all writing references to it were allowed.
-                    allowed = allWritingRefsAllowed;
-                }
-            }
+            allowed = this.isAllowedIdentifier(expression, escapeObject, details);
         }
         else {
             // everything that doesn't match is unsafe:
             allowed = false;
+        }
+        return allowed;
+    },
+
+    /**
+     * Check if an identifier is allowed
+     * - find its declarations and see if it's const or let
+     * - if so, allow if the declaring statement is an allowed expression
+     * - ensure that following assignments to that identifier are also allowed
+     *
+     * @param {Object} expression Identifier expression
+     * @param {Object} escapeObject contains keys "methods" and "taggedTemplates" which are arrays of strings
+     *                              of matching escaping function names.
+     * @param {Object} details Additional linter violation state information, in case this function was called
+     *                         recursively.
+     * @returns {boolean} Returns whether the Identifier is deemed safe.
+     */
+    isAllowedIdentifier(expression, escapeObject, details) {
+        // find declared variables and see which are literals
+        const scope = this.context.getScope(expression);
+        const variableInfo = scope.set.get(expression.name);
+        let allowed = false;
+
+        // If we can't get info on the variable, we just can't allow it
+        if (!variableInfo ||
+            !variableInfo.defs ||
+            !variableInfo.defs.length > 0 ||
+            !variableInfo.references ||
+            !variableInfo.references.length > 0) {
+            // FIXME Fix/Adjust towards a helpful message here and update tests accordingly.
+            // details.message = `Variable ${expression.name} considered unsafe: variable initialization not found`;
+            return false;
+        }
+
+        // look if the var was defined as allowable
+        let definedAsAllowed = false;
+        for (const def of variableInfo.defs) {
+            if (def.node.type !== "VariableDeclarator") {
+                // What else could it be..
+                const {line, column} = def.node;
+                details.message = `Variable '${expression.name}' initialized with unknown declaration at ${line}:${column}`;
+
+                break;
+            }
+            if ((def.kind !== "let") && (def.kind !== "const")) {
+                // We do not allow for identifiers declared with "var", as they can be overridden in a
+                // way that is hard for us to follow (e.g., assignments to globalThis[theirNameAsString]).
+                break;
+            }
+
+            // the `init` property carries the right-hand side of the variable definition:
+            const varInitAs = def.node.init;
+            if (!this.allowedExpression(varInitAs, escapeObject, details)) {
+                // if one variable definition is considered unsafe, all are.
+                // NB: order of definition is unclear. See issue #168.
+                if (!details.message) {
+                    const {line, column} = varInitAs.loc.start;
+                    details.message = `Variable '${expression.name}' initialized with unsafe value at ${line}:${column}`;
+                }
+                definedAsAllowed = false;
+                break;
+            }
+
+            // keep iterating through other definitions.
+            definedAsAllowed = true;
+        }
+        if (definedAsAllowed) {
+            // the variable was declared as a safe value (e.g., literal)
+            // now inspect writing references to that variable
+            let allWritingRefsAllowed = false;
+            for (const ref of variableInfo.references) {
+                // only look into writing references
+                if (ref.isWrite()) {
+                    const writeExpr = ref.writeExpr;
+
+                    // if one is unsafe we'll consider all unsafe.
+                    // this is because code occurring doesn't guarantee it being executed
+                    // due to dynamic behavior if-conditions and such
+                    if (!this.allowedExpression(writeExpr, escapeObject, details)) {
+                        if (!details.message) {
+                            const {line, column} = writeExpr.loc.start;
+                            details.message = `Variable '${expression.name}' reassigned with unsafe value at ${line}:${column}`;
+                        }
+                        allWritingRefsAllowed = false;
+                        break;
+                    }
+                    allWritingRefsAllowed = true;
+                }
+            }
+
+            // allow this variable, because all writing references to it were allowed.
+            allowed = allWritingRefsAllowed;
         }
         return allowed;
     },

--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -118,9 +118,9 @@ RuleHelper.prototype = {
         // If we can't get info on the variable, we just can't allow it
         if (!variableInfo ||
             !variableInfo.defs ||
-            !variableInfo.defs.length > 0 ||
+            variableInfo.defs.length == 0 ||
             !variableInfo.references ||
-            !variableInfo.references.length > 0) {
+            variableInfo.references.length == 0) {
             // FIXME Fix/Adjust towards a helpful message here and update tests accordingly.
             // details.message = `Variable ${expression.name} considered unsafe: variable initialization not found`;
             return false;
@@ -133,12 +133,13 @@ RuleHelper.prototype = {
                 // What else could it be..
                 const {line, column} = def.node;
                 details.message = `Variable '${expression.name}' initialized with unknown declaration at ${line}:${column}`;
-
+                definedAsAllowed = false;
                 break;
             }
             if ((def.kind !== "let") && (def.kind !== "const")) {
                 // We do not allow for identifiers declared with "var", as they can be overridden in a
                 // way that is hard for us to follow (e.g., assignments to globalThis[theirNameAsString]).
+                definedAsAllowed = false;
                 break;
             }
 

--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -97,6 +97,12 @@ RuleHelper.prototype = {
                 let definedAsAllowed = false;
                 for (const def of variableInfo.defs) {
                     if (def.node.type === "VariableDeclarator") {
+                        if ((def.kind !== "let") && (def.kind !== "const")) {
+                            // We do not allow for identifiers declared with "var", as they can be overridden in a
+                            // way that is hard for us to follow (e.g., assignments to globalThis[theirNameAsString]).
+                            continue;
+                        }
+
                         // the `init` property carries the right-hand side of the variable definition:
                         const varInitAs = def.node.init;
                         if (!this.allowedExpression(varInitAs, escapeObject, details)) {

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -822,6 +822,19 @@ eslintTester.run("method", rule, {
             ]
         },
         {
+
+            // This test ensures we do not allow _var_ declarations traced back as "safe"
+            // because it could be modified through dynamical global scope operations,
+            // e.g., globalThis['copies'] and we don't want to trace through those.
+            code: "var copies = '<b>safe</b>'; /* some modifications with globalThis['copies'] */;  n.insertAdjacentHTML('beforebegin', copies);",
+            errors: [
+                {
+                    message: /Unsafe call to n.insertAdjacentHTML for argument 1/,
+                    type: "CallExpression"
+                }
+            ],
+        },
+        {
             code: "let copies = evil; n.insertAdjacentHTML('beforebegin', copies);",
             errors: [
                 {
@@ -850,6 +863,6 @@ eslintTester.run("method", rule, {
                     type: "FantasyCallee"
                 }
             ]
-        }        
+        }
     ]
 });

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -822,7 +822,7 @@ eslintTester.run("method", rule, {
             ]
         },
         {
-            code: "var copies = evil; n.insertAdjacentHTML('beforebegin', copies);",
+            code: "let copies = evil; n.insertAdjacentHTML('beforebegin', copies);",
             errors: [
                 {
                     message: /Unsafe call to n.insertAdjacentHTML for argument 1 \(Variable 'copies' initialized with unsafe value at \d+:\d+\)/,
@@ -832,7 +832,7 @@ eslintTester.run("method", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "var copies = '<b>safe</b>'; copies = suddenlyUnsafe; n.insertAdjacentHTML('beforebegin', copies);",
+            code: "let copies = '<b>safe</b>'; copies = suddenlyUnsafe; n.insertAdjacentHTML('beforebegin', copies);",
             errors: [
                 {
                     message: /Unsafe call to n.insertAdjacentHTML for argument 1 \(Variable 'copies' reassigned with unsafe value at \d+:\d+\)/,

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -822,6 +822,26 @@ eslintTester.run("method", rule, {
             ]
         },
         {
+            code: "var copies = evil; n.insertAdjacentHTML('beforebegin', copies);",
+            errors: [
+                {
+                    message: /Unsafe call to n.insertAdjacentHTML for argument 1 \(Variable 'copies' initialized with unsafe value at \d+:\d+\)/,
+                    type: "CallExpression"
+                }
+            ],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var copies = '<b>safe</b>'; copies = suddenlyUnsafe; n.insertAdjacentHTML('beforebegin', copies);",
+            errors: [
+                {
+                    message: /Unsafe call to n.insertAdjacentHTML for argument 1 \(Variable 'copies' reassigned with unsafe value at \d+:\d+\)/,
+                    type: "CallExpression"
+                }
+            ],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
             code: "§fantasyCallee§()",
             parser: require.resolve("../parsers/fantasy-callee"),
             errors: [
@@ -830,6 +850,6 @@ eslintTester.run("method", rule, {
                     type: "FantasyCallee"
                 }
             ]
-        }
+        }        
     ]
 });

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -854,6 +854,42 @@ eslintTester.run("method", rule, {
             ],
             parserOptions: { ecmaVersion: 6 }
         },
+
+        // Variable tracked back to a parameter part of a FunctionDeclaration.
+        {
+            code: "function test(evil) { let copies = '<b>safe</b>'; copies = evil; n.insertAdjacentHTML('beforebegin', copies); }",
+            errors: [
+                {
+                    message: /Unsafe call to n.insertAdjacentHTML for argument 1 \(Variable 'evil' declared as function parameter, which is considered unsafe. 'FunctionDeclaration' at \d+:\d+\)/,
+                    type: "CallExpression"
+                }
+            ],
+            parserOptions: { ecmaVersion: 6 }
+        },
+
+        // Variable tracked back to a parameter part of a FunctionExpression.
+        {
+            code: "const fn = function (evil) { let copies = '<b>safe</b>'; copies = evil; n.insertAdjacentHTML('beforebegin', copies); }",
+            errors: [
+                {
+                    message: /Unsafe call to n.insertAdjacentHTML for argument 1 \(Variable 'evil' declared as function parameter, which is considered unsafe. 'FunctionExpression' at \d+:\d+\)/,
+                    type: "CallExpression"
+                }
+            ],
+            parserOptions: { ecmaVersion: 6 }
+        },
+
+        // Variable tracked back to a parameter part of a ArrowFunctionExpression.
+        {
+            code: "const fn = (evil) => { let copies = '<b>safe</b>'; copies = evil; n.insertAdjacentHTML('beforebegin', copies); }",
+            errors: [
+                {
+                    message: /Unsafe call to n.insertAdjacentHTML for argument 1 \(Variable 'evil' declared as function parameter, which is considered unsafe. 'ArrowFunctionExpression' at \d+:\d+\)/,
+                    type: "CallExpression"
+                }
+            ],
+            parserOptions: { ecmaVersion: 6 }
+        },
         {
             code: "§fantasyCallee§()",
             parser: require.resolve("../parsers/fantasy-callee"),

--- a/tests/rules/property.js
+++ b/tests/rules/property.js
@@ -554,7 +554,7 @@ eslintTester.run("property", rule, {
             code: "var copies = '<b>safe</b>'; copies = suddenlyUnsafe; y.innerHTML = copies;",
             errors: [
                 {
-                    message: "Unsafe assignment to innerHTML",
+                    message: /Unsafe assignment to innerHTML \(Variable 'copies' reassigned with unsafe value at \d+:\d+\)/,
                     type: "AssignmentExpression"
                 }
             ],
@@ -564,7 +564,7 @@ eslintTester.run("property", rule, {
             code: "var copies = '<b>safe</b>'; var copies = suddenlyUnsafe; y.innerHTML = copies;",
             errors: [
                 {
-                    message: "Unsafe assignment to innerHTML",
+                    message: /Unsafe assignment to innerHTML \(Variable 'copies' initialized with unsafe value at \d+:\d+\)/,
                     type: "AssignmentExpression"
                 }
             ],
@@ -574,7 +574,36 @@ eslintTester.run("property", rule, {
             code: "var copies = '<b>safe</b>'; if (monday) { copies = badness }; y.innerHTML = copies;",
             errors: [
                 {
-                    message: "Unsafe assignment to innerHTML",
+                    message: /Unsafe assignment to innerHTML \(Variable 'copies' reassigned with unsafe value at \d+:\d+\)/,
+                    type: "AssignmentExpression"
+                }
+            ],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: `var copies = "<b>safe</b>";
+              (() => {
+                  copies = badness;
+              })();
+              y.innerHTML = copies;
+            `,
+            errors: [
+                {
+                    message: /Unsafe assignment to innerHTML \(Variable 'copies' reassigned with unsafe value at \d+:\d+\)/,
+                    type: "AssignmentExpression"
+                }
+            ],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: `var obj = { prop: "<b>safe</b>" };
+              doSomething(obj);
+              var copies = obj.prop;
+              y.innerHTML = copies;
+            `,
+            errors: [
+                {
+                    message: /Unsafe assignment to innerHTML \(Variable 'copies' initialized with unsafe value at \d+:\d+\)/,
                     type: "AssignmentExpression"
                 }
             ],

--- a/tests/rules/property.js
+++ b/tests/rules/property.js
@@ -209,7 +209,7 @@ eslintTester.run("property", rule, {
 
         // support for variables that are declared elsewhere
         {
-            code: "var literalFromElsewhere = '<b>safe</b>'; y.innerHTML = literalFromElsewhere;",
+            code: "let literalFromElsewhere = '<b>safe</b>'; y.innerHTML = literalFromElsewhere;",
             parserOptions: { ecmaVersion: 6 }
         },
         {
@@ -217,19 +217,19 @@ eslintTester.run("property", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "var multiStepVarSearch = '<b>safe</b>'+'yo'; const copy = multiStepVarSearch; y.innerHTML = copy;",
+            code: "let multiStepVarSearch = '<b>safe</b>'+'yo'; const copy = multiStepVarSearch; y.innerHTML = copy;",
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "var copies = '<b>safe</b>'; var copies = 'stillOK'; y.innerHTML = copies;",
+            code: "let copies = '<b>safe</b>'; copies = 'stillOK'; y.innerHTML = copies;",
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "var copies = '<b>safe</b>'; if (monday) { copies = 'stillOK'; }; y.innerHTML = copies;",
+            code: "let copies = '<b>safe</b>'; if (monday) { copies = 'stillOK'; }; y.innerHTML = copies;",
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "var msg = '<b>safe</b>'; var altMsg = 'also cool';  if (monday) { msg = altMsg; }; y.innerHTML = msg;",
+            code: "let msg = '<b>safe</b>'; let altMsg = 'also cool';  if (monday) { msg = altMsg; }; y.innerHTML = msg;",
             parserOptions: { ecmaVersion: 6 }
         },
     ],
@@ -551,7 +551,7 @@ eslintTester.run("property", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "var copies = '<b>safe</b>'; copies = suddenlyUnsafe; y.innerHTML = copies;",
+            code: "let copies = '<b>safe</b>'; copies = suddenlyUnsafe; y.innerHTML = copies;",
             errors: [
                 {
                     message: /Unsafe assignment to innerHTML \(Variable 'copies' reassigned with unsafe value at \d+:\d+\)/,
@@ -561,17 +561,7 @@ eslintTester.run("property", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "var copies = '<b>safe</b>'; var copies = suddenlyUnsafe; y.innerHTML = copies;",
-            errors: [
-                {
-                    message: /Unsafe assignment to innerHTML \(Variable 'copies' initialized with unsafe value at \d+:\d+\)/,
-                    type: "AssignmentExpression"
-                }
-            ],
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "var copies = '<b>safe</b>'; if (monday) { copies = badness }; y.innerHTML = copies;",
+            code: "let copies = '<b>safe</b>'; if (monday) { copies = badness }; y.innerHTML = copies;",
             errors: [
                 {
                     message: /Unsafe assignment to innerHTML \(Variable 'copies' reassigned with unsafe value at \d+:\d+\)/,
@@ -581,7 +571,7 @@ eslintTester.run("property", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: `var copies = "<b>safe</b>";
+            code: `let copies = "<b>safe</b>";
               (() => {
                   copies = badness;
               })();
@@ -596,9 +586,9 @@ eslintTester.run("property", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: `var obj = { prop: "<b>safe</b>" };
+            code: `let obj = { prop: "<b>safe</b>" };
               doSomething(obj);
-              var copies = obj.prop;
+              let copies = obj.prop;
               y.innerHTML = copies;
             `,
             errors: [

--- a/tests/rules/property.js
+++ b/tests/rules/property.js
@@ -95,7 +95,6 @@ eslintTester.run("property", rule, {
             code: "y.innerHTML = '<span>' + 5 + '</span>';",
             parserOptions: { ecmaVersion: 6 }
         },
-
         {
             code: "document.writeln(Sanitizer.escapeHTML`<em>${evil}</em>`);",
             parserOptions: { ecmaVersion: 6 }
@@ -208,6 +207,31 @@ eslintTester.run("property", rule, {
             parser: PATH_TO_BABEL_ESLINT,
         },
 
+        // support for variables that are declared elsewhere
+        {
+            code: "var literalFromElsewhere = '<b>safe</b>'; y.innerHTML = literalFromElsewhere;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "const literalFromElsewhereWithInnerExpr = '<b>safe</b>'+'yo'; y.innerHTML = literalFromElsewhereWithInnerExpr;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var multiStepVarSearch = '<b>safe</b>'+'yo'; const copy = multiStepVarSearch; y.innerHTML = copy;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var copies = '<b>safe</b>'; var copies = 'stillOK'; y.innerHTML = copies;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var copies = '<b>safe</b>'; if (monday) { copies = 'stillOK'; }; y.innerHTML = copies;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var msg = '<b>safe</b>'; var altMsg = 'also cool';  if (monday) { msg = altMsg; }; y.innerHTML = msg;",
+            parserOptions: { ecmaVersion: 6 }
+        },
     ],
 
     // Examples of code that should trigger the rule
@@ -515,6 +539,46 @@ eslintTester.run("property", rule, {
                 }
             ],
             parser: PATH_TO_BABEL_ESLINT,
+        },
+        {
+            code: "copy = '<b>safe</b>'; copy = evil; y.innerHTML = copy;",
+            errors: [
+                {
+                    message: "Unsafe assignment to innerHTML",
+                    type: "AssignmentExpression"
+                }
+            ],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var copies = '<b>safe</b>'; copies = suddenlyUnsafe; y.innerHTML = copies;",
+            errors: [
+                {
+                    message: "Unsafe assignment to innerHTML",
+                    type: "AssignmentExpression"
+                }
+            ],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var copies = '<b>safe</b>'; var copies = suddenlyUnsafe; y.innerHTML = copies;",
+            errors: [
+                {
+                    message: "Unsafe assignment to innerHTML",
+                    type: "AssignmentExpression"
+                }
+            ],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var copies = '<b>safe</b>'; if (monday) { copies = badness }; y.innerHTML = copies;",
+            errors: [
+                {
+                    message: "Unsafe assignment to innerHTML",
+                    type: "AssignmentExpression"
+                }
+            ],
+            parserOptions: { ecmaVersion: 6 }
         },
         {
             code: "a.innerHTML §= b;",


### PR DESCRIPTION
I realize this is quite a change, but it seems relatively easy and very useful :)

Issue #167 has a bit of an explanation and the tests carry a lot of the wright, but I'm still a bit concerned that this might break stuff.
For testing, I'll explore running this on popular repos that are alraedy using this rule.

- [x] Run against mozilla-central (i.e., Firefox frontend)
- [x] find a Mozilla web extension to test against this new logic
- [ ] find an external project that uses this plugin and see what happens