### PR TITLE
Add test for unexpected expressions

### DIFF
--- a/tests/parsers/fantasy-callee.js
+++ b/tests/parsers/fantasy-callee.js
@@ -1,0 +1,58 @@
+"use strict";
+
+/**
+ * Parser: fantasy-callable
+ * Source code: §fantasyCallee§()
+ */
+
+exports.parse = () => ({
+    "type": "Program",
+    "start": 0,
+    "end": 5,
+    "loc": {},
+    "comments": [],
+    "errors": [],
+    "range": [
+        0,
+        5
+    ],
+    "tokens": [],
+    "body": [
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": 0,
+                "end": 5
+            },
+            "range": [
+                0,
+                5
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": 0,
+                    "end": 5
+                },
+                "range": [
+                    0,
+                    5
+                ],
+                "callee": {
+                    "type": "FantasyCallee",
+                    "loc": {
+                        "start": 0,
+                        "end": 3
+                    },
+                    "range": [
+                        0,
+                        3
+                    ],
+                    "name": "§fantasyCallee§"
+                },
+                "arguments": []
+            }
+        }
+    ],
+    "sourceType": "module"
+});

--- a/tests/parsers/fantasy-operator.js
+++ b/tests/parsers/fantasy-operator.js
@@ -1,0 +1,138 @@
+"use strict";
+
+/**
+ * Parser: fantasy-callable
+ * Source code: a.innerHTML §= b
+ */
+
+exports.parse = () => ({
+    "type": "Program",
+    "start": 0,
+    "end": 5,
+    "loc": {},
+    "comments": [],
+    "errors": [],
+    "range": [
+        0,
+        5
+    ],
+    "tokens": [],
+    "body": [
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": 0,
+                "end": 5
+            },
+            "range": [
+                0,
+                5
+            ],
+            "expression": {
+                "type": "AssignmentExpression",
+                "start": 1,
+                "end": 6,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 1
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 6
+                    }
+                },
+                "range": [
+                    1,
+                    6
+                ],
+                "operator": "§=",
+                "left": {
+                    "type": "MemberExpression",
+                    "start": 1,
+                    "end": 4,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 1
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 4
+                        }
+                    },
+                    "range": [
+                        1,
+                        4
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "start": 1,
+                        "end": 2,
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 1
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 2
+                            },
+                            "identifierName": "a"
+                        },
+                        "range": [
+                            1,
+                            2
+                        ],
+                        "name": "a",
+                    },
+                    "computed": false,
+                    "property": {
+                        "type": "Identifier",
+                        "start": 3,
+                        "end": 4,
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 3
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 4
+                            },
+                            "identifierName": "innerHTML"
+                        },
+                        "range": [
+                            3,
+                            4
+                        ],
+                        "name": "a",
+                    },
+                    "optional": false,
+                },
+                "right": {
+                    "type": "Identifier",
+                    "start": 5,
+                    "end": 6,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 5
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 6
+                        },
+                        "identifierName": "b"
+                    },
+                    "range": [
+                        5,
+                        6
+                    ],
+                    "name": "b",
+                },
+            },
+        }
+    ],
+    "sourceType": "module"
+});

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -821,5 +821,15 @@ eslintTester.run("method", rule, {
                 }
             ]
         },
+        {
+            code: "§fantasyCallee§()",
+            parser: require.resolve("../parsers/fantasy-callee"),
+            errors: [
+                {
+                    message: "Error in no-unsanitized: Unexpected Callee. Please report a minimal code snippet to the developers at https://github.com/mozilla/eslint-plugin-no-unsanitized/issues/new?title=Unsupported%20Callee%20of%20type%20FantasyCallee%20for%20CallExpression",
+                    type: "FantasyCallee"
+                }
+            ]
+        }
     ]
 });

--- a/tests/rules/property.js
+++ b/tests/rules/property.js
@@ -516,5 +516,15 @@ eslintTester.run("property", rule, {
             ],
             parser: PATH_TO_BABEL_ESLINT,
         },
+        {
+            code: "a.innerHTML §= b;",
+            errors: [
+                {
+                    message: "Error in no-unsanitized: Unexpected Assignment. Please report a minimal code snippet to the developers at https://github.com/mozilla/eslint-plugin-no-unsanitized/issues/new?title=Unsupported%20Operator%20%25C2%25A7%253D%20for%20AssignmentExpression",
+                    type: "AssignmentExpression"
+                }
+            ],
+            parser: require.resolve("../parsers/fantasy-operator"),
+        },
     ]
 });


### PR DESCRIPTION
Context and how eslint suggests we solve this is in https://github.com/eslint/eslint/issues/14776, but let me re-iterate for posterity:

We try be exhaustive in terms of Expressions we can analyze. In particular, we want to complain for expressions that are not within a list of allowed expressions. This helps maintain the security guarantees we provide in our plugin and acts as a forcing function to adopt new JavaScript Syntax in lock-step with the tooling that is used to check it.

So far, we haven't been able to test for this scenario because it's hard to come up with the unknowns about non-existing JavaScript source.

However, as per the eslint issue above we can just make stuff up and define a parser that returns an AST with completely hypothetical syntax. Writing your own parser was easier than it sounds, the eslint folks use it themselves for their tests: The trick is to write a parser custom for this specific test case and make it return a pre-defined AST that is completely independent of the input.

I've used the terms "FantasyCallee" and "FantasyOperator" that should help identify the unexpected AST nodes in tests as well as the custom parser.