### PR TITLE
fix: normalizeMethodCall should expect a CallExpression node

### DIFF
--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -128,6 +128,7 @@ RuleHelper.prototype = {
             methodName = node.property.name;
             objectName = node.object.name || this.context.getSource(node.object);
             break;
+        case "CallExpression":
         case "ArrowFunctionExpression":
             methodName = "";
             break;

--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -128,6 +128,7 @@ RuleHelper.prototype = {
             methodName = node.property.name;
             objectName = node.object.name || this.context.getSource(node.object);
             break;
+        case "ConditionalExpression":
         case "CallExpression":
         case "ArrowFunctionExpression":
             methodName = "";

--- a/tests/rules/property.js
+++ b/tests/rules/property.js
@@ -529,6 +529,18 @@ eslintTester.run("property", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
 
+        // Ensure normalizeMethodCall expects a CallExpression with a ConditionalExpression callee.
+        {
+            code: "a.innerHTML = (cond ? maybe_safe : or_evil)()",
+            errors: [
+                {
+                    message: "Unsafe assignment to innerHTML",
+                    type: "AssignmentExpression"
+                }
+            ],
+            parserOptions: { ecmaVersion: 6 }
+        },
+
         // Explicitly cover behavior on new unexpected operators.
         {
             code: "a.innerHTML §= b;",

--- a/tests/rules/property.js
+++ b/tests/rules/property.js
@@ -516,6 +516,20 @@ eslintTester.run("property", rule, {
             ],
             parser: PATH_TO_BABEL_ESLINT,
         },
+
+        // Ensure normalizeMethodCall expects a CallExpression with a CallExpression callee.
+        {
+            code: "a.innerHTML = somefn()()",
+            errors: [
+                {
+                    message: "Unsafe assignment to innerHTML",
+                    type: "AssignmentExpression"
+                }
+            ],
+            parserOptions: { ecmaVersion: 6 }
+        },
+
+        // Explicitly cover behavior on new unexpected operators.
         {
             code: "a.innerHTML §= b;",
             errors: [


### PR DESCRIPTION
We do already expect "ArrowFunctionExpression" in normalizeMethodCall, and so it seems reasonable to also expect "CallExpression" (and return an empty method name as we are doing for the "ArrowFunctionExpression").

At the moment code like the one in the test case is triggering the additonal linting issue that we log for unexpected cases we would like to be reported as new issue in this repo.