### PR TITLE
Fix error when `node.init` is `null`

### DIFF
--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -163,7 +163,9 @@ RuleHelper.prototype = {
 
             // the `init` property carries the right-hand side of the variable definition:
             const varInitAs = def.node.init;
-            if (!this.allowedExpression(varInitAs, escapeObject, details)) {
+
+            // When the variable is only declared but not initialized, `init` is `null`.
+            if (varInitAs && !this.allowedExpression(varInitAs, escapeObject, details)) {
                 // if one variable definition is considered unsafe, all are.
                 // NB: order of definition is unclear. See issue #168.
                 if (!details.message) {
@@ -181,6 +183,13 @@ RuleHelper.prototype = {
             // the variable was declared as a safe value (e.g., literal)
             // now inspect writing references to that variable
             let allWritingRefsAllowed = false;
+
+            // With no write variable references, if it was defined as allowed
+            // then we should consider it safe.
+            if (variableInfo.references.filter(ref => ref.isWrite()).length === 0) {
+                allWritingRefsAllowed = true;
+            }
+
             for (const ref of variableInfo.references) {
                 // only look into writing references
                 if (ref.isWrite()) {

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -346,6 +346,12 @@ eslintTester.run("method", rule, {
                 sourceType: "module",
             }
         },
+
+        // let without initialization.
+        {
+            code: "let c; n.insertAdjacentHTML('beforebegin', c)",
+            parserOptions: { ecmaVersion: 6 }
+        },
     ],
 
     // Examples of code that should trigger the rule
@@ -912,6 +918,25 @@ eslintTester.run("method", rule, {
                     type: "FantasyCallee"
                 }
             ]
-        }
+        },
+        {
+            code: `
+              let c;
+              if (cond) {
+                c = '<b>safe</b>';
+              } else {
+                c = evil;
+              }
+              n.insertAdjacentHTML('beforebegin', \`\${c}\`);
+            `,
+            errors: [
+                {
+                    message: /Unsafe call to n.insertAdjacentHTML for argument 1/,
+                    type: "CallExpression"
+                }
+            ],
+            parserOptions: { ecmaVersion: 6 }
+        },
+
     ]
 });

--- a/tests/rules/property.js
+++ b/tests/rules/property.js
@@ -92,6 +92,15 @@ eslintTester.run("property", rule, {
             code: "i.outerHTML += Sanitizer.unwrapSafeHTML(htmlSnippet)",
             parserOptions: { ecmaVersion: 6 }
         },
+        {
+            code: "let c; c = 123; a.innerHTML = `${c}`;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "let c; a.innerHTML = `${c}`;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+
 
         // (binary) expressions
         {
@@ -663,6 +672,36 @@ eslintTester.run("property", rule, {
                 }
             ],
             parser: require.resolve("../parsers/fantasy-operator"),
+        },
+
+        // Uninitialized variable declaration.
+        {
+            code: `
+              let c;
+              if (cond) {
+                c = '<b>safe</b>';
+              } else {
+                c = evil;
+              }
+              a.innerHTML = \`\${c}\`;
+            `,
+            errors: [
+                {
+                    message: /Unsafe assignment to innerHTML/,
+                    type: "AssignmentExpression"
+                }
+            ],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "let c; c = 'apparently-safe'; functionCall(c); n.innerHTML = c.property;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: /Unsafe assignment to innerHTML/,
+                    type: "AssignmentExpression"
+                }
+            ],
         },
     ]
 });


### PR DESCRIPTION
Fixes #188

---

This PR fixes the issue reported in #188 by checking that `node.init` is
valid before using it. From there, I added two test cases and the code
basically told me where to put them (i.e. valid or invalid lists).