### PR TITLE
Change default branch to main, remove nodejs v12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
-    branches: [master, main]
+    branches: [main]
 
 jobs:
   ci:
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         eslint-version: [8.x, 7.x, 6.x]
-        node-version: [16.x, 14.x, 12.x]
+        node-version: [16.x, 14.x]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
node v12 leaves long-term support end of this month.