### PR TITLE
Ensure Sanitizer API's setHTML() is allowed (see #197)

### DIFF
--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -352,6 +352,15 @@ eslintTester.run("method", rule, {
             code: "let c; n.insertAdjacentHTML('beforebegin', c)",
             parserOptions: { ecmaVersion: 6 }
         },
+        {
+            code: "x.setHTML(evil)"
+        },
+        {
+            code: "x.setHTML(evil, { sanitizer: s })"
+        },
+        {
+            code: "x.setHTML(evil, { sanitizer: new Sanitizer()})"
+        }
     ],
 
     // Examples of code that should trigger the rule


### PR DESCRIPTION
#197 requested support for the built-in Sanitizer API.
As one of the co-editors, I know that only `element.setHTML()` is stable enough for support.

`sanitizeFor()` has been removed from Gecko and we still have not reached consensus on how to spec & ship `sanitize()`. So this commit doesn't completely fix #197 and will require future work if we end up shipping more than just setHTML.