### PR TITLE
fix `(a.b = c)(d);` parsing

### DIFF
--- a/lib/rules/method.js
+++ b/lib/rules/method.js
@@ -99,15 +99,23 @@ function checkCallExpression(ruleHelper, callExpr, node) {
         break;
     }
 
-    case "AssignmentExpression":
-        if (node.right.type === "MemberExpression") {
-            const newCallExpr = Object.assign({}, callExpr);
-            newCallExpr.callee = node.right;
-            checkCallExpression(ruleHelper, newCallExpr, node.right);
-            break;
-        }
-        checkCallExpression(ruleHelper, callExpr, node.right);
+    case "AssignmentExpression": {
+        // TODO This assumes `node.operator` is always `=`, so `AssignmentExpression`
+        // should evaluate to the right side. This is not true for, for example:
+        // ```
+        // const a = () => console.log('a');
+        // const b = () => console.log('b');
+        // let c = a;
+        // (c ||= b)()
+        // ```
+        // which will print `a`.
+        // https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators-runtime-semantics-evaluation
+        // Looking at Uglify.js / Terser code could help.
+        const newCallExpr = Object.assign({}, callExpr);
+        newCallExpr.callee = node.right;
+        checkCallExpression(ruleHelper, newCallExpr, node.right);
         break;
+    }
 
     case "Import":
         ruleHelper.checkMethod(callExpr);

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -118,6 +118,9 @@ eslintTester.run("method", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
+            code: "(a.b = c)(d);",
+        },
+        {
             code: "(text.endsWith('\\n') ? document.write : document.writeln)(text)"
         },
 
@@ -758,6 +761,20 @@ eslintTester.run("method", rule, {
                 }
             ]
         },
+
+        // Couldn't come up with an example that would work now, so let's uncomment this when
+        // https://github.com/mozilla/eslint-plugin-no-unsanitized/issues/115
+        // is done.
+        // {
+        //     code: "var shortcut = node.insertAdjacentHTML.bind(node); "
+        //         + "(a.b = shortcut)('beforebegin', evil)",
+        //     errors: [
+        //         {
+        //             message: "Unsafe call to node.insertAdjacentHTML for argument 1",
+        //             type: "CallExpression"
+        //         }
+        //     ]
+        // },
         {
             code: "(9)()",
             errors: [


### PR DESCRIPTION
Not sure how to fix this though

https://github.com/mozilla/eslint-plugin-no-unsanitized/blob/8dae8ae6db66a3ea91b5d2d9469f8e78666ee2fb/lib/rules/method.js#L71-L76

My guess is that `"Identifier"` should be handled differently from `"MemberExpression"` (maybe we're supposed to just `break;` on it?)

Feel free to fix it yourself.

Related (see code): #115