### PR TITLE
Fix flat recommended

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,10 @@ Object.assign(plugin.configs, {
         plugins: ["no-unsanitized"],
         rules,
     },
-    recommended: [
-        {
-            plugins: { "no-unsanitized": plugin },
-            rules,
-        },
-    ],
+    recommended: {
+        plugins: { "no-unsanitized": plugin },
+        rules,
+    },
 });
 
 module.exports = plugin;


### PR DESCRIPTION
The usage example in README is incorrect. Could fix README, but this approach is easier to deal with (e.g., when you want to just add `files: [...]` to it). This is a breaking change, unfortunately.