### PR TITLE
Add TSAsExpression Test

### DIFF
--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -450,6 +450,10 @@ eslintTester.run("method", rule, {
             // # 232: disallow setHTMLUnsafe, but OK with static string.
             code: "foo.setHTMLUnsafe('static string')",
         },
+        {
+            code: "(foo as Function)();",
+            ...TYPESCRIPT_OPTIONS,
+        },
     ],
 
     // Examples of code that should trigger the rule
@@ -1055,6 +1059,16 @@ eslintTester.run("method", rule, {
                     type: "CallExpression",
                 },
             ],
+        },
+        {
+            code: "document.write(badness);",
+            errors: [
+                {
+                    message: /Unsafe call to document.write for argument 0/,
+                    type: "CallExpression",
+                },
+            ],
+            ...TYPESCRIPT_OPTIONS,
         },
     ],
 });


### PR DESCRIPTION
Fixes #180 

Added a test to test the TSAsExpression in lib/rules/method.js

Before:
![image](https://github.com/user-attachments/assets/3bc44b9e-51fb-4caa-b9cc-4e51a5ff0ad9)
After:
![image](https://github.com/user-attachments/assets/6875cb37-2cc1-4c7f-8b5b-154d9fb1c737)

I am new to this repo, I can help with the other uncovered lines if needed. 😊
