### PR TITLE
Fix usage example for flat config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ export default config = [
         files: ["**/*.js"],
         plugins: { nounsanitized },
         rules: {
-            "no-unsanitized/method": "error",
-            "no-unsanitized/property": "error",
+            "nounsanitized/method": "error",
+            "nounsanitized/property": "error",
         },
     },
 ];


### PR DESCRIPTION
The plugin name in rules is misspelled as `no-unsanitized` instead of `nounsanitized`.