### PR TITLE
Fix: disallow extra properties in rule options

### DIFF
--- a/lib/rules/method.js
+++ b/lib/rules/method.js
@@ -182,6 +182,7 @@ module.exports = {
                                 items: [{ type: "string" }],
                             },
                         },
+                        additionalProperties: false,
                     },
                     objectMatches: {
                         type: "array",

--- a/lib/rules/property.js
+++ b/lib/rules/property.js
@@ -44,6 +44,7 @@ module.exports = {
                                 items: [{ type: "string" }],
                             },
                         },
+                        additionalProperties: false,
                     },
                     variableTracing: { type: "boolean" },
                 },


### PR DESCRIPTION
Plugin rules currently allow extra properties to be passed in options object in certain places, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in rules' schemas which currently allow them.