### PR TITLE
Fix: Enhance RuleHelper to prevent infinite recursion

### DIFF
--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -166,6 +166,19 @@ RuleHelper.prototype = {
             return false;
         }
 
+        // Initialize the checking stack if it doesn't exist
+        if (!details.checkingIdentifiers) {
+            details.checkingIdentifiers = new Set();
+        }
+
+        // Prevent infinite recursion by checking if we're already analyzing this identifier
+        if (details.checkingIdentifiers.has(expression.name)) {
+            return false;
+        }
+
+        // Add this identifier to the checking stack
+        details.checkingIdentifiers.add(expression.name);
+
         // find declared variables and see which are literals
         const scope = getScope(this.context, expression);
         const variableInfo = scope.variableScope.set.get(expression.name);
@@ -275,6 +288,10 @@ RuleHelper.prototype = {
             // allow this variable, because all writing references to it were allowed.
             allowed = allWritingRefsAllowed;
         }
+
+        // Remove this identifier from the checking stack before returning
+        details.checkingIdentifiers.delete(expression.name);
+
         return allowed;
     },
 

--- a/tests/rules/property.js
+++ b/tests/rules/property.js
@@ -728,5 +728,16 @@ eslintTester.run("property", rule, {
                 },
             ],
         },
+        // Test for recursive variable reference (should not cause stack overflow but should be flagged as unsafe)
+        {
+            code: "let text = ''; text = `${text}<p>`; scratchDiv.innerHTML = text;",
+            ...ECMA_VERSION_6_ONLY_OPTIONS,
+            errors: [
+                {
+                    message: /Unsafe assignment to innerHTML.*Variable 'text' reassigned with unsafe value/,
+                    type: "AssignmentExpression",
+                },
+            ],
+        },
     ],
 });

--- a/tests/rules/property.js
+++ b/tests/rules/property.js
@@ -734,7 +734,8 @@ eslintTester.run("property", rule, {
             ...ECMA_VERSION_6_ONLY_OPTIONS,
             errors: [
                 {
-                    message: /Unsafe assignment to innerHTML.*Variable 'text' reassigned with unsafe value/,
+                    message:
+                        /Unsafe assignment to innerHTML.*Variable 'text' reassigned with unsafe value/,
                     type: "AssignmentExpression",
                 },
             ],


### PR DESCRIPTION
The `no-unsanitized/property` rule crashes with the following code:

```js
const scratchDiv = document.createElement("div");
function foo() {
  let text = "";
  // This next line causes "Maximum call stack size exceeded"
  text = `${text}<p>`;
  scratchDiv.innerHTML = text;
}
```

This PR fixes it by keeping track of expressions being checked and not revisiting them. 

<details><summary>Full error message (with user dir redacted):</summary>
<p>
Oops! Something went wrong! :(

ESLint: 9.17.0

RangeError: Maximum call stack size exceeded
Occurred while linting foo.js:6
Rule: "no-unsanitized/property"
    at RuleHelper.isAllowedIdentifier (/Users/joebloggs/foo/node_modules/.pnpm/eslint-plugin-no-unsanitized@4.1.2_eslint@9.17.0_jiti@2.4.1_/node_modules/eslint-plugin-no-unsanitized/lib/ruleHelper.js:165:19)
    at RuleHelper.allowedExpression (/Users/joebloggs/foo/node_modules/.pnpm/eslint-plugin-no-unsanitized@4.1.2_eslint@9.17.0_jiti@2.4.1_/node_modules/eslint-plugin-no-unsanitized/lib/ruleHelper.js:130:32)
    at /Users/joebloggs/foo/node_modules/.pnpm/eslint-plugin-no-unsanitized@4.1.2_eslint@9.17.0_jiti@2.4.1_/node_modules/eslint-plugin-no-unsanitized/lib/ruleHelper.js:143:22
    at Array.every (<anonymous>)
    at RuleHelper.allowedExpression (/Users/joebloggs/foo/node_modules/.pnpm/eslint-plugin-no-unsanitized@4.1.2_eslint@9.17.0_jiti@2.4.1_/node_modules/eslint-plugin-no-unsanitized/lib/ruleHelper.js:142:34)
    at RuleHelper.allowedExpression (/Users/joebloggs/foo/node_modules/.pnpm/eslint-plugin-no-unsanitized@4.1.2_eslint@9.17.0_jiti@2.4.1_/node_modules/eslint-plugin-no-unsanitized/lib/ruleHelper.js:83:32)
    at RuleHelper.isAllowedIdentifier (/Users/joebloggs/foo/node_modules/.pnpm/eslint-plugin-no-unsanitized@4.1.2_eslint@9.17.0_jiti@2.4.1_/node_modules/eslint-plugin-no-unsanitized/lib/ruleHelper.js:258:31)
    at RuleHelper.allowedExpression (/Users/joebloggs/foo/node_modules/.pnpm/eslint-plugin-no-unsanitized@4.1.2_eslint@9.17.0_jiti@2.4.1_/node_modules/eslint-plugin-no-unsanitized/lib/ruleHelper.js:130:32)
    at /Users/todd/macdev/itwin/studio/node_modules/.pnpm/eslint-plugin-no-unsanitized@4.1.2_eslint@9.17.0_jiti@2.4.1_/node_modules/eslint-plugin-no-unsanitized/lib/ruleHelper.js:143:22
    at Array.every (<anonymous>)
</p>
</details> 
