### PR TITLE
docs: Use noUnsanitized (camelCase)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,23 +59,23 @@ $ npm install --save-dev eslint-plugin-no-unsanitized
 ### Flat config
 
 ```js
-import nounsanitized from "eslint-plugin-no-unsanitized";
+import noUnsanitized from "eslint-plugin-no-unsanitized";
 
-export default config = [nounsanitized.configs.recommended];
+export default config = [noUnsanitized.configs.recommended];
 ```
 
 or
 
 ```js
-import nounsanitized from "eslint-plugin-no-unsanitized";
+import noUnsanitized from "eslint-plugin-no-unsanitized";
 
 export default config = [
     {
         files: ["**/*.js"],
-        plugins: { nounsanitized },
+        plugins: { noUnsanitized },
         rules: {
-            "nounsanitized/method": "error",
-            "nounsanitized/property": "error",
+            "noUnsanitized/method": "error",
+            "noUnsanitized/property": "error",
         },
     },
 ];


### PR DESCRIPTION
It's difficult to read `nounsanitized` (in lowercase). Personally, I read _noun sanitized_. I suggest putting it in camelCase to make it easier to read.