### PR TITLE
Improve inferred type for type checked eslint configs

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const plugin = {
                 'The "DOM" configuration of the "no-unsanitized" plugin is deprecated. Use "recommended-legacy" instead.'
             );
 
-            return plugin.configs["recommended-legacy"];
+            return this["recommended-legacy"];
         },
     },
 };


### PR DESCRIPTION
Define the exported plugin with its almost complete shape, including config keys. Only delay assignment of the flat config's plugin value (and the placeholder `{}` actually adheres to the `ESLint.Plugin` type, so is valid). After these changes, the inferred types satisfy type checked ESLint configs.

**Special note**
While it is possible to define `configs.recommended.plugins["no-unsanitized"]` as a getter, the inferred type runs into an infinite recursion problem. So, late assignment of the property is still waranted.

**Demo**
Before
<img width="733" height="108" alt="image" src="https://github.com/user-attachments/assets/53ccdb3f-1856-45bf-b7ad-6fd7accc57cc" />

After
<img width="688" height="153" alt="image" src="https://github.com/user-attachments/assets/023835e6-a676-4576-927a-7fb2aef5b711" />
