### PR TITLE
Fix broken markdown link and add DOMPurify configuration setup

### DIFF
--- a/docs/rules/customization.md
+++ b/docs/rules/customization.md
@@ -83,6 +83,42 @@ You can customize the way this rule works in various ways.
 }
 ```
 
+### Allow innerHTML when assignment happens through third-party sanitization library (DOMPurify)
+
+**DOMPurify:**
+
+Allow `DOMPurify.sanitize` method:
+
+```html    
+<script>
+    document.querySelector("p").innerHTML = DOMPurify.sanitize( unsafeHTML );
+</script>
+```
+
+Configuration:
+
+```js
+{
+    plugins: { nounsanitized },
+    rules: {
+      "nounsanitized/method": [
+        "error",
+        { 
+            "escape": { 
+                "methods": ["DOMPurify.sanitize"] 
+            } 
+        }],
+      "nounsanitized/property": [
+        "error", 
+        { 
+            "escape": { 
+                "methods": ["DOMPurify.sanitize"] 
+            } 
+        }],
+    },
+}
+```
+
 ### Override list of escaping functions for property assignments only
 
 TBD

--- a/docs/rules/fixing-violations.md
+++ b/docs/rules/fixing-violations.md
@@ -10,7 +10,7 @@ your code would look like this:
 foo.innerHTML = DOMPurify.sanitize(<a href="${link}">click</a>);
 ```
 
-Please also see the [customization docs](customization.md] to
+Please also see the [customization docs](customization.md) to
 change the allowed sanitizer calls.
 
 # That still does not solve my problem


### PR DESCRIPTION
- Fixing broken markdown link (missing closing parentheses):
  - `[customization docs](customization.md]` -> `[customization docs](customization.md)` 
- Add configuration example for use with DOMPurify library
