### PR TITLE
Handle TS as expressions in method call checks

### DIFF
--- a/lib/rules/method.js
+++ b/lib/rules/method.js
@@ -129,8 +129,12 @@ function checkCallExpression(ruleHelper, callExpr, node) {
             break;
         }
 
-        case "TSAsExpression":
+        case "TSAsExpression": {
+            const newCallExpr = Object.assign({}, callExpr);
+            newCallExpr.callee = node.expression;
+            checkCallExpression(ruleHelper, newCallExpr, node.expression);
             break;
+        }
 
         // those are fine:
         case "LogicalExpression": // Should we scan these? issue #62.

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -345,6 +345,10 @@ eslintTester.run("method", rule, {
             code: "node!().insertAdjacentHTML('beforebegin', 'raw string');",
             ...TYPESCRIPT_OPTIONS,
         },
+        {
+            code: "(foo as Function)();",
+            ...TYPESCRIPT_OPTIONS,
+        },
 
         // Flow support tests
         {
@@ -819,6 +823,15 @@ eslintTester.run("method", rule, {
                 {
                     message:
                         "Unsafe call to x as HTMLElement.insertAdjacentHTML for argument 1",
+                },
+            ],
+        },
+        {
+            code: "(document.write as Function)(evil)",
+            ...TYPESCRIPT_OPTIONS,
+            errors: [
+                {
+                    message: "Unsafe call to document.write for argument 0",
                 },
             ],
         },


### PR DESCRIPTION
## Summary
- unwrap `TSAsExpression` callees before checking unsafe method calls
- add TypeScript RuleTester coverage for a safe casted call and an unsafe casted `document.write` call

Fixes #180

## Verification
- `npm test` (182 passing)
- `npx eslint lib/rules/method.js tests/rules/method.js`
- `npx prettier --check lib/rules/method.js tests/rules/method.js`

Note: full `npm run lint` on my Windows checkout reports Prettier line-ending warnings across existing untouched files, so I verified the changed files directly.