### PR TITLE
Check unsafe bound method calls

### DIFF
--- a/lib/rules/method.js
+++ b/lib/rules/method.js
@@ -129,6 +129,21 @@ function checkCallExpression(ruleHelper, callExpr, node) {
             break;
         }
 
+        case "CallExpression":
+            if (
+                node.callee.type === "MemberExpression" &&
+                node.callee.property.name === "bind"
+            ) {
+                const newCallExpr = Object.assign({}, callExpr);
+                newCallExpr.callee = node.callee.object;
+                checkCallExpression(
+                    ruleHelper,
+                    newCallExpr,
+                    node.callee.object
+                );
+            }
+            break;
+
         case "TSAsExpression":
             break;
 
@@ -138,7 +153,6 @@ function checkCallExpression(ruleHelper, callExpr, node) {
         case "ArrowFunctionExpression":
         case "FunctionExpression":
         case "Super":
-        case "CallExpression":
         case "ThisExpression":
         case "NewExpression":
         case "TSTypeAssertion":

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -395,6 +395,12 @@ eslintTester.run("method", rule, {
             code: "(info.current = n.insertAdjacentHTML)('beforebegin', 'innocent')",
         },
         {
+            code: "foo.bind(bar).baz()",
+        },
+        {
+            code: 'document.body.insertAdjacentHTML.bind(document.body)("afterend", "harmless")',
+        },
+        {
             // #214: We also allow *harmful* parameters.
             code: "let l = ['afterend', 'harmless']; foo.insertAdjacentHTML(...l);",
             ...ECMA_VERSION_2020_ONLY_OPTIONS,
@@ -956,6 +962,15 @@ eslintTester.run("method", rule, {
                 {
                     message:
                         /Unsafe call to n.insertAdjacentHTML for argument 1/,
+                },
+            ],
+        },
+        {
+            code: 'document.body.insertAdjacentHTML.bind(document.body)("afterend", foo)',
+            errors: [
+                {
+                    message:
+                        /Unsafe call to document.body.insertAdjacentHTML for argument 1/,
                 },
             ],
         },


### PR DESCRIPTION
## Summary
- inspect call expressions created from `.bind(...)` and re-run the method check against the original bound method
- add coverage for valid bound calls and an unsafe bound `insertAdjacentHTML` call

Fixes #115

## Verification
- `npm test` (183 passing)
- `npx eslint lib/rules/method.js tests/rules/method.js`
- `npx prettier --check lib/rules/method.js tests/rules/method.js`

Note: full `npm run lint` on my Windows checkout reports Prettier line-ending warnings across existing untouched files, so I verified the changed files directly.