### PR TITLE
Add SBOM/dependabot config as suggested by forthcoming SSDLC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: weekly
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,8 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    cooldown:
-      default-days: 7
-    schedule:
-      interval: weekly
-
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      cooldown:
+          default-days: 7
+      schedule:
+          interval: weekly

--- a/.github/sbom.yml
+++ b/.github/sbom.yml
@@ -1,0 +1,21 @@
+name: ssdlc-sbom
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - '*' # all tags
+
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  sbom:
+    uses: mozilla/ssdlc-actions/.github/workflows/ssdlc-sbom.yml@5cc2b20e42d53d1643853f12244fbec9ed2f2e0c
+    with:
+      sbom_name: ${{ github.event.release.tag_name || github.sha }}
+

--- a/.github/sbom.yml
+++ b/.github/sbom.yml
@@ -1,21 +1,20 @@
 name: ssdlc-sbom
 
 on:
-  release:
-    types: [published]
-  push:
-    tags:
-      - '*' # all tags
+    release:
+        types: [published]
+    push:
+        tags:
+            - "*" # all tags
 
-  workflow_dispatch:
+    workflow_dispatch:
 
 permissions:
-  actions: read
-  contents: write
+    actions: read
+    contents: write
 
 jobs:
-  sbom:
-    uses: mozilla/ssdlc-actions/.github/workflows/ssdlc-sbom.yml@5cc2b20e42d53d1643853f12244fbec9ed2f2e0c
-    with:
-      sbom_name: ${{ github.event.release.tag_name || github.sha }}
-
+    sbom:
+        uses: mozilla/ssdlc-actions/.github/workflows/ssdlc-sbom.yml@5cc2b20e42d53d1643853f12244fbec9ed2f2e0c
+        with:
+            sbom_name: ${{ github.event.release.tag_name || github.sha }}


### PR DESCRIPTION
The security org wants to establish an SSDLC that is consistent across all githubp projects and I want to help by piloting their sbom workflows in our repo. This is a test and should not influence how we typicall do things too much (I hope :))
